### PR TITLE
Add a pokemon marker size (#169)

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -311,6 +311,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
 
     private void setPokemonMarkers(final List<CatchablePokemon> pokeList){
         positionNum++;
+        int markerSize = getResources().getDimensionPixelSize(R.dimen.pokemon_marker);
         if (mGoogleMap != null) {
 
             Set<String> markerKeys = markerList.keySet();
@@ -323,7 +324,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                             .asBitmap()
                             .skipMemoryCache(false)
                             .diskCacheStrategy(DiskCacheStrategy.ALL)
-                            .into(new SimpleTarget<Bitmap>(120, 120) { // Width and height FIXME: Maybe get different sizes based on devices DPI? this need tests
+                            .into(new SimpleTarget<Bitmap>(markerSize, markerSize) { // Width and height FIXME: Maybe get different sizes based on devices DPI? this need tests
                                 @Override
                                 public void onResourceReady(Bitmap bitmap, GlideAnimation anim) {
                                     //Setting marker since we got image

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,6 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+
+    <dimen name="pokemon_marker">36dp</dimen>
 </resources>


### PR DESCRIPTION
Setting up pokemon marker size to 36 dp x 36 dp.
May need to look into sizing the pokestop icon in a similar fashion